### PR TITLE
fixjstypo

### DIFF
--- a/LeafletBlazor/wwwroot/leafletBlazorInterops.js
+++ b/LeafletBlazor/wwwroot/leafletBlazorInterops.js
@@ -400,7 +400,7 @@ window.leafletVideoOverlayLayer = {
 window.leafletMarkerLayer = {
     create: function (mapId, marker, objectReference) {
         const layerOptions = {
-            icon = marker.options.icon ? createLeafletIcon(marker.options.icon) : undefined,
+            icon: marker.options.icon ? createLeafletIcon(marker.options.icon) : undefined,
             keyboard: marker.options.keyboard,
             title: marker.options.title,
             alt: marker.options.alt,


### PR DESCRIPTION
Fix compile error in LeafletBlazor\wwwroot\leafletBlazorInterops.js line 403:

```
icon: marker.options.icon ? createLeafletIcon(marker.options.icon) : undefined,
```

